### PR TITLE
Add "raw" handling to builder, processor

### DIFF
--- a/lib/csdl/builder.rb
+++ b/lib/csdl/builder.rb
@@ -241,27 +241,24 @@ module CSDL
     end
 
     # Create a node to store raw CSDL.
+    # @note this method will not implicitly wrap the raw CSDL in any grouping or scope.
     #
     # @example
     #   node = CSDL::Builder.new.raw(%q{fb.content contains_any "foo" OR fb.parent.content contains_any "foo"})
     #   CSDL::Processor.new.process(node) # => %q{fb.content contains_any "foo" OR fb.parent.content contains_any "foo"}
     #
-    # @example Multiple conditions ANDed together
-    #   nodes = CSDL::Builder.new._and do
+    # @example Using with other generated nodes (e.g. condition)
+    #   nodes = CSDL::Builder.new._or do
     #     [
-    #       condition("fb.content", :contains, "this is a string"),
-    #       condition("fb.parent.content", :contains, "this is a string"),
+    #       condition("fb.type", :exists),
+    #       logical_group { raw(%q{fb.content contains_any "foo" OR fb.parent.content contains_any "foo"}) }
     #     ]
     #   end
-    #   CSDL::Processor.new.process(nodes) # => 'fb.content contains "this is a string" AND fb.parent.content contains "this is a string"'
+    #   CSDL::Processor.new.process(nodes) # => 'fb.type exists OR (fb.content contains_any "foo" OR fb.parent.content contains_any "foo")'
     #
-    # @param target [#to_s] A valid Target specifier (see {CSDL::TARGETS}).
-    # @param operator [#to_s] A valid Operator specifier (see {CSDL::OPERATORS}).
-    # @param argument [String, Numeric, nil] The comparator value, if applicable for the given operator.
+    # @param raw_csdl [#to_s] The raw CSDL to store.
     #
-    # @return [AST::Node] An AST :condition node with child target, operator, and argument nodes.
-    #
-    # @see #_not
+    # @return [AST::Node] An AST :raw node.
     #
     def raw(raw_csdl)
       s(:raw, raw_csdl.to_s)

--- a/lib/csdl/builder.rb
+++ b/lib/csdl/builder.rb
@@ -240,6 +240,33 @@ module CSDL
       end
     end
 
+    # Create a node to store raw CSDL.
+    #
+    # @example
+    #   node = CSDL::Builder.new.raw(%q{fb.content contains_any "foo" OR fb.parent.content contains_any "foo"})
+    #   CSDL::Processor.new.process(node) # => %q{fb.content contains_any "foo" OR fb.parent.content contains_any "foo"}
+    #
+    # @example Multiple conditions ANDed together
+    #   nodes = CSDL::Builder.new._and do
+    #     [
+    #       condition("fb.content", :contains, "this is a string"),
+    #       condition("fb.parent.content", :contains, "this is a string"),
+    #     ]
+    #   end
+    #   CSDL::Processor.new.process(nodes) # => 'fb.content contains "this is a string" AND fb.parent.content contains "this is a string"'
+    #
+    # @param target [#to_s] A valid Target specifier (see {CSDL::TARGETS}).
+    # @param operator [#to_s] A valid Operator specifier (see {CSDL::OPERATORS}).
+    # @param argument [String, Numeric, nil] The comparator value, if applicable for the given operator.
+    #
+    # @return [AST::Node] An AST :condition node with child target, operator, and argument nodes.
+    #
+    # @see #_not
+    #
+    def raw(raw_csdl)
+      s(:raw, raw_csdl.to_s)
+    end
+
     # Wrap child nodes in a root node. Useful for building CSDL with tagging and a return statement.
     #
     # @example

--- a/lib/csdl/processor.rb
+++ b/lib/csdl/processor.rb
@@ -164,6 +164,22 @@ module CSDL
       logically_join_nodes("OR", node.children)
     end
 
+    # Process :raw nodes.
+    #
+    # @example
+    #   node = s(:raw, %q{fb.content contains_any "foo" OR fb.parent.content contains_any "foo"})
+    #   CSDL::Processor.new.process(node) # => 'fb.content contains_any "foo" OR fb.parent.content contains_any "foo"'
+    #
+    # @param node [AST::Node] The :raw node to be processed.
+    #
+    # @return [String] The first child node as a string.
+    #
+    # @todo Raise if the node doesn't have any children.
+    #
+    def on_raw(node)
+      node.children.first.to_s
+    end
+
     # Process all child nodes. Useful for grouping child nodes without any syntax introduction.
     #
     # @see InteractionFilterProcessor#_return

--- a/test/csdl/builder_test.rb
+++ b/test/csdl/builder_test.rb
@@ -418,6 +418,31 @@ class BuilderTest < ::MiniTest::Test
     assert_equal(expected, actual)
   end
 
+  def test_raw
+    expected = s(:raw, %q{fb.content contains_any "foo" OR fb.parent.content contains_any "foo"})
+    actual = ::CSDL::Builder.new.raw(%q{fb.content contains_any "foo" OR fb.parent.content contains_any "foo"})
+
+    assert_equal(expected, actual)
+  end
+
+  def test_raw_combined_with_ast_nodes
+    expected = s(:or,
+                 s(:condition,
+                   s(:target, "fb.type"),
+                   s(:operator, :exists)),
+                 s(:logical_group,
+                   s(:raw, %q{fb.content contains_any "foo" OR fb.parent.content contains_any "foo"})))
+
+    actual = ::CSDL::Builder.new._or do
+      [
+        condition("fb.type", :exists),
+        logical_group { raw(%q{fb.content contains_any "foo" OR fb.parent.content contains_any "foo"}) }
+      ]
+    end
+
+    assert_equal(expected, actual)
+  end
+
   def test_return
     expected = s(:return,
                  s(:statement_scope,

--- a/test/csdl/processor_test.rb
+++ b/test/csdl/processor_test.rb
@@ -195,10 +195,23 @@ class ProcessorTest < ::MiniTest::Test
     assert_csdl_equal(expected, sexp)
   end
 
-  def test_raw_csdl
+  def test_raw
     raw = %q{fb.content contains_any "foo" OR fb.parent.content contains_any "foo"}
     sexp = s(:raw, raw)
     assert_csdl_equal(raw, sexp)
+  end
+
+  def test_raw_grouped_with_other_conditions
+    expected = %q{fb.type exists OR (fb.content contains_any "foo" OR fb.parent.content contains_any "foo")}
+    sexp = s(:or,
+             s(:condition,
+               s(:target, "fb.type"),
+               s(:operator, :exists)),
+             s(:logical_group,
+               s(:raw, %q{fb.content contains_any "foo" OR fb.parent.content contains_any "foo"})))
+
+
+    assert_csdl_equal(expected, sexp)
   end
 
   private

--- a/test/csdl/processor_test.rb
+++ b/test/csdl/processor_test.rb
@@ -195,6 +195,12 @@ class ProcessorTest < ::MiniTest::Test
     assert_csdl_equal(expected, sexp)
   end
 
+  def test_raw_csdl
+    raw = %q{fb.content contains_any "foo" OR fb.parent.content contains_any "foo"}
+    sexp = s(:raw, raw)
+    assert_csdl_equal(raw, sexp)
+  end
+
   private
 
   def assert_csdl_equal(expected, sexp)


### PR DESCRIPTION
Using the `raw` method on the builder will produce a `:raw` AST node, which when
processed will simply stringify it's first child node.

This allows you to provide your own raw CSDL that may have been generated outside
of a builder. This provides a halfway step to a parser, which I'd like to avoid
adding for now.

Note that the raw node will do zero parsing or validation of the given CSDL.